### PR TITLE
Update Sphinx configuration path in Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ build:
     python: "3.13"
 
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
 
 python:
   install:


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of the PR's purpose here. -->
This PR will fix an issue with Read the Docs where the file location within the `.pre-commit-config.yaml` file.

## Changes
<!-- List all the changes introduced in this PR. -->
### Fix file location within `.pre-commit-config.yaml`:
- Change location from `docs/conf.py` &rarr; `docs/source/conf.py`

## Impact
- This will ensure Read the Docs has the correct location to build and `Sphnix` documentation correctly.