### PR TITLE
Added project status section with badges for build, documentation, PyPI, and quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# Python-Template
+Python-Template
+==============================
 A template repository for Python projects within the CCPBioSim organisation
+
+## Project Status
+
+| Category       | Badges |
+|----------------|--------|
+| **Build**      | [![CI](https://github.com/CCPBioSim/Python-Template/actions/workflows/example_package_project-ci.yaml/badge.svg)](https://github.com/CCPBioSim/Python-Template/actions/workflows/example_package_project-ci.yaml) |
+| **Documentation** | [![Docs – Status](https://app.readthedocs.org/projects/ccpbiosim-python-template/badge/?version=latest)](https://ccpbiosim-python-template.readthedocs.io/en/latest/) |
+| **PyPI**       | [![PyPI - Version](https://img.shields.io/pypi/v/CCPBioSim-Python-Template.svg)](https://pypi.org/project/CCPBioSim-Python-Template/) [![PyPI - Status](https://img.shields.io/pypi/status/CCPBioSim-Python-Template.svg)](https://pypi.org/project/CCPBioSim-Python-Template/) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/CCPBioSim-Python-Template.svg)](https://pypi.org/project/CCPBioSim-Python-Template/) [![PyPI - Downloads](https://img.shields.io/pypi/dm/CCPBioSim-Python-Template.svg)](https://pypi.org/project/CCPBioSim-Python-Template/) |
+| **Quality**    | [![Coverage Status](https://coveralls.io/repos/github/CCPBioSim/Python-Template/badge.svg?branch=main)](https://coveralls.io/github/CCPBioSim/Python-Template?branch=main) |


### PR DESCRIPTION
## Summary
This PR improves the `README.md` by introducing a **Project Status** section that organises key badges (CI, docs, PyPI, coverage) into a clean Markdown table, making the project’s health and release status easier to understand at a glance.

## Changes
### Add Project Status table to README:
- Added a `## Project Status` section near the top of the README.
- Grouped badges into a two-column Markdown table with categories: **Build**, **Documentation**, **PyPI**, and **Quality**.

## Impact
- Enhances readability and professionalism of the README.
- Makes it easier for users and contributors to quickly see build, docs, package, and coverage status.
- Provides a clearer template structure for future CCPBioSim Python projects to follow.