### PR TITLE
Automate yearly copyright update in license file

### DIFF
--- a/.github/workflows/update-copyright-years-in-license-file.yaml
+++ b/.github/workflows/update-copyright-years-in-license-file.yaml
@@ -1,0 +1,17 @@
+name: Update copyright year(s) in license file
+
+on:
+  schedule:
+    - cron: '0 3 1 1 *' # 03:00 AM on January 1
+  workflow_dispatch:
+
+jobs:
+    update-license-year:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+            - uses: FantasticFiasco/action-update-license-year@v3
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
This PR introduces a GitHub Action that automatically updates the copyright year in the license file.

## Changes
### Added `.github/workflows/update-copyright-years-in-license-file.yaml`
- Runs annually on January 1st at 3:00 AM
- Can also be triggered manually via `workflow_dispatch`

## Impact
- Ensures the copyright year remains accurate without manual intervention
- Reduces the risk of outdated licensing information