### PR TITLE
Enable parallel execution for Coveralls GitHub Action

### DIFF
--- a/.github/workflows/example_package_project-ci.yaml
+++ b/.github/workflows/example_package_project-ci.yaml
@@ -35,6 +35,7 @@ jobs:
         uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e # v2.3.7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel: true
 
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
<!-- Provide a brief description of the PR's purpose here. -->
This PR will introduce a parallel build option for coveralls to avoid the failing PRs which come in with quick succession to each other.

## Changes
<!-- List all the changes introduced in this PR. -->
### Add Parallel Build Option in `.github/workflows/example_package_project-ci.yaml`
- Add an extra step with `parallel-finished: true`

## Impact
- This will ensure that any future CI runs involving coveralls uses the parallel version and avoid the crash of jobs