### PR TITLE
Set fail-on-error to false in CI workflow

### DIFF
--- a/.github/workflows/example_package_project-ci.yaml
+++ b/.github/workflows/example_package_project-ci.yaml
@@ -36,6 +36,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           parallel: true
+          fail-on-error: false
 
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
This PR updates the CI coverage configuration to prevent failures caused by intermittent downtime from Coveralls. By setting the coverage step to `fail-on-error: false`, we ensure that CI runs are not marked as failed due to external service instability rather than issues within the codebase.

## Changes
### Make coverage reporting non-blocking:
- Updated the CI configuration to set the Coveralls step to `fail-on-error: false`.
- Prevented CI pipelines from failing when Coveralls is unavailable or experiencing downtime.
- Ensured coverage reporting continues to run without impacting overall build success.

## Impact
- Improves CI reliability by removing dependency on Coveralls uptime for build success.
- Prevents false-negative CI failures caused by external service outages.
- Maintains coverage reporting without disrupting workflows.